### PR TITLE
FIX: Use two_through_five consistently

### DIFF
--- a/array_practice.ipynb
+++ b/array_practice.ipynb
@@ -168,7 +168,7 @@
    "outputs": [],
    "source": [
     "#- 1D array 2 through 5\n",
-    "two_through_5 = np.arange(...)\n",
+    "two_through_five = np.arange(...)\n",
     "# Show the result\n",
     "two_through_five"
    ]


### PR DESCRIPTION
I'm assuming that this wasn't intentionally there for students to fix.