### PR TITLE
ENH: use Python's built-in ``help()`` instead of mentioning docstrings

### DIFF
--- a/array_practice.ipynb
+++ b/array_practice.ipynb
@@ -341,7 +341,9 @@
    "id": "7737a4b3",
    "metadata": {},
    "source": [
-    "Look at the docstring for `rng.standard_normal`.  Here's a cell that you can\n",
+    "It is fundamental to know how to get help - Python provides a *built-in* (meaning, standard) function called [`help()`](https://docs.python.org/3/library/functions.html#help)\n",
+    "You can invoke `help()` whenever you want to know more about an object, function, variable, etc.\n"
+    "Let's use `help()` to learn more about `rng.standard_normal`.  Here's a cell that you can\n",
     "use to do that.  In particular, check out the examples.  "
    ]
   },
@@ -352,7 +354,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rng..."
+    "help(...)"
    ]
   },
   {


### PR DESCRIPTION
I feel docstrings are a more advanced concept than `help()` - hope you agree.